### PR TITLE
Added my esbuild-mdx plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This is just a centralized list of 3rd-party plugins to make discovery easier. N
 ## Plugin list
 
 * [esbuild-graphql-loader](https://github.com/luckycatfactory/esbuild-graphql-loader): A plugin allowing for GraphQL file imports.
+* [esbuild-mdx](https://github.com/zaydek/esbuild-mdx): A plugin to render `.md` and `.mdx`-delimited files as React components.
 * [esbuild-plugin-cache](https://github.com/dalcib/esbuild-plugin-cache): A plugin to cache http/https modules. It works with [import-maps](https://github.com/WICG/import-maps).
 * [esbuild-plugin-flow](https://github.com/dalcib/esbuild-plugin-flow): A plugin to strip types for Flow files using flow-remove-types package.
 * [esbuild-plugin-glsl](https://github.com/vanruesc/esbuild-plugin-glsl): A plugin that adds support for GLSL file imports with optional shader minification.


### PR DESCRIPTION
Added plugin https://github.com/zaydek/esbuild-mdx, which is published to NPM as `esbuild-mdx`. There is also a reference implementation provided at https://github.com/zaydek/esbuild-mdx-example, which is linked to in the original readme.