### PR TITLE
Adds `@yarnpkg/esbuild-plugin-pnp`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This is just a centralized list of 3rd-party plugins to make discovery easier. N
 
 ## Plugin list
 
+* [@yarnpkg/esbuild-plugin-pnp](https://github.com/yarnpkg/berry/tree/master/packages/esbuild-plugin-pnp#yarnpkgesbuild-plugin-pnp): A plugin adding support for [Yarn Plug'n'Play](https://yarnpkg.com/features/pnp) installs.
 * [esbuild-graphql-loader](https://github.com/luckycatfactory/esbuild-graphql-loader): A plugin allowing for GraphQL file imports.
 * [esbuild-plugin-cache](https://github.com/dalcib/esbuild-plugin-cache): A plugin to cache http/https modules. It works with [import-maps](https://github.com/WICG/import-maps).
 * [esbuild-plugin-flow](https://github.com/dalcib/esbuild-plugin-flow): A plugin to strip types for Flow files using flow-remove-types package.


### PR DESCRIPTION
I've published our official plugin to npm. It's also covered by live tests, so it should always work (and of course we'll maintain it, since we use it in our builds now 🙂).
