### PR TITLE
Add esbuild-plugin-webpack-bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ This is just a centralized list of 3rd-party plugins to make discovery easier. N
 * [esbuild-plugin-pnp](https://github.com/shiftx/esbuild-plugin-pnp): A plugin to support yarn 2 (berry) with PnP (Plug’n’Play).
 * [esbuild-plugin-postcss-literal](https://github.com/nativew/esbuild-plugin-postcss-literal): A plugin to transform tagged template literals with PostCSS.
 * [esbuild-plugin-velcro](https://github.com/ggoodman/esbuild-plugin-velcro): A plugin to load npm (bare module) dependencies from the cloud and requiring no previous npm install.
+* [esbuild-plugin-webpack-bridge](https://github.com/igoradamenko/esbuild-plugin-webpack-bridge): A plugin that allows to use webpack loaders.
 * [esbuild-svelte-paths](https://github.com/alexxnb/esbuild-svelte-paths): A plugin that resolves shortcuted pathes for Svelte components.
 
 ## How to use a plugin


### PR DESCRIPTION
Hello [again](https://github.com/esbuild/community-plugins/pull/31) :-)

I'm still trying to rewrite one of my project's setup from webpack to esbuild, and here's a plugin I'm currently working on. It allows to use webpack loaders with esbuild.

Not sure that it will be possible to shim all the webpack's API, but some main loaders already works.