### PR TITLE
Add `esbuild-css-modules-plugin`

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is just a centralized list of 3rd-party plugins to make discovery easier. N
 ## Plugin list
 
 ### New file extensions
-
+* [esbuild-css-modules-plugin](https://github.com/indooorsman/esbuild-css-modules-plugin#readme): A plugin to bundle `xxx.modules.css` or `xxx.module.css` into `.js(x)/.ts(x)`. Can build with both `bundle: true` & `bundle: false`.
 * [@offen/esbuild-plugin-jsonschema](https://github.com/offen/esbuild-plugin-jsonschema): Compile and pack JSON schema definitions on import.
 * [esbuild-graphql-loader](https://github.com/luckycatfactory/esbuild-graphql-loader): A plugin allowing for GraphQL file imports.
 * [esbuild-mdx](https://github.com/zaydek/esbuild-mdx): A plugin to render `.md` and `.mdx`-delimited files as React components.


### PR DESCRIPTION
Add `esbuild-css-modules-plugin`<https://github.com/indooorsman/esbuild-css-modules-plugin>, A plugin to bundle `xxx.modules.css` or `xxx.module.css` into `.js(x)/.ts(x)`. Can build with both `bundle: true` & `bundle: false`.