### PR TITLE
add local-dev-server to work with esbuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ This is just a centralized list of 3rd-party plugins to make discovery easier. N
 
 ### Other plugins (hosted on npm)
 
+* [local-dev-server](https://github.com/lv-saharan/local-dev): a dev server easy to work with esbuild.
 * [@anatine/esbuild-decorators](https://github.com/anatine/esbuildnx/tree/main/packages/esbuild-decorators): This is a plugin for esbuild to handle the tsconfig setting `"emitDecoratorMetadata": true` using tsc to transpile `.ts` or `.tsx` files with decorators.
 * [@craftamap/esbuild-plugin-html](https://github.com/craftamap/esbuild-plugin-html) A Plugin to create `*.html`-files from specified entry points.
 * [@datadog/build-plugin](https://github.com/DataDog/build-plugin) A plugin to monitor your build performances.


### PR DESCRIPTION
```javascript
import { dev } from "local-dev-server";
let buildResult=null
const { reload } = dev({
  port: 9000,
  response: (filePath, res) => {
    //if use esbuild ,and write:false
    //find the contents of esbuild

    const outfile = buildResult?.outputFiles.find(
      (file) => file.path == filePath
    );
    if (outfile) {
      res.setHeader("Content-Type", "application/javascript;charset=utf-8");
      res.end(outfile.contents);
      return true;
    }
    return false;
  },
});
//some code
//.....
esbuild.build({
    ...options,
    entryPoints: [infile],
    outfile,
    write:false
    watch:

    {
        onRebuild(error, result) {
            if (error) console.error('watch build failed:', error)
            else {
                console.log('watch build succeeded:', result)
                //when esbuild rebuild,call reload function
                buildResult=result
                reload("esbuild rebuild ok,reload now!")
            }
        },
    }
}).then(result => {
    console.log(`build  ${module} ok!`)
    buildResult=result
})
```
