### PR TITLE
docs: add `esbuild-plugin-global-api`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This is just a centralized list of 3rd-party plugins to make discovery easier. N
 * [esbuild-plugin-ajv](https://github.com/mister-what/esbuild-plugin-ajv): A plugin to load and compile standalone validation code from JSON Schema / JSON Type Definition.
 * [esbuild-plugin-css-modules](https://github.com/koluch/esbuild-plugin-css-modules): Another one plugin to support CSS-modules (partially)
 * [esbuild-plugin-elm](https://github.com/phenax/esbuild-plugin-elm): A plugin to compile an elm project with esbuild.
+* [esbuild-plugin-global-api](https://github.com/DarrenDanielDay/esbuild-plugin-global-api): An esbuild plugin for simplifying global API calls.
 * [esbuild-plugin-glsl](https://github.com/vanruesc/esbuild-plugin-glsl): A plugin that adds support for GLSL file imports with optional shader minification.
 * [esbuild-plugin-glslify-inline](https://github.com/marcofugaro/esbuild-plugin-glslify-inline): A plugin to process inline GLSL strings with [glslify](https://github.com/glslify/glslify).
 * [esbuild-plugin-glslify](https://github.com/darionco/esbuild-plugin-glslify): A plugin to import GLSL strings with [glslify](https://github.com/glslify/glslify) (a node.js-style module system for GLSL).


### PR DESCRIPTION
This plugin has the general purpose of simplifying global API calls like `Object.keys`, `Object.defineProperty`, inspired by the following output code of `esbuild`:

```js
var __create = Object.create;
var __defProp = Object.defineProperty;
var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
var __getOwnPropNames = Object.getOwnPropertyNames;
var __getProtoOf = Object.getPrototypeOf;
var __hasOwnProp = Object.prototype.hasOwnProperty;
```

This plugin plays a trick of `ES Module` namespace import and tree shaking. It inserts code like this for each matched file at `onLoad`.

```js
import * as Object from "@esbuild-plugin-global-api/do-not-use-in-your-code-Object";
```

And then resolve the trick module `@esbuild-plugin-global-api/do-not-use-in-your-code-Object` as an internal namespaced package, and load it with code like this:

```js
const keys = Object.keys;
const defineProperty = Object.defineProperty;
export { keys, defineProperty };
```

I think `esbuild` itself can include such feature, just analyze the AST and simplify it in place, since `esbuild` will emit errors for `new expression` and `call expression` with imported as namespace "variables", that is, `esbuild` will emit errors if your source code has expressions like `new Object()`. Sorry that I'm not familiar with `golang`, so I just implemented my idea as an `JavaScript` plugin trick🤣.