### PR TITLE
Add esbuild_serve to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ This is just a centralized list of 3rd-party plugins to make discovery easier. N
 * [esbuild-plugin-eval](https://deno.land/x/esbuild_plugin_eval): A plugin that evaluates a module before importing it.
 * [esbuild-plugin-http-fetch](https://deno.land/x/esbuild_plugin_http_fetch): A plugin that resolves http(s) modules, for use with browsers and Deno.
 * [esbuild-plugin-sass-deno](https://deno.land/x/esbuild_plugin_sass_deno@v0.1.0): A Plugin which adds support for SASS/SCSS using `denosass`. 
+* [esbuild-serve](https://deno.land/x/esbuild_serve): A plugin improving Deno DX with persistent HTTP importing, AutoTemplates, a DevServer and more.
 
 ## How to use a plugin
 


### PR DESCRIPTION
esbuild_serve tries to improve Deno DX with persistent HTTP importing, AutoTemplates, a DevServer and more.