### PR TITLE
Add esbuild-plugin-liquid

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ This is just a centralized list of 3rd-party plugins to make discovery easier. N
 * [esbuild-plugin-imagemin](https://github.com/omyasn/esbuild-plugin-imagemin): A plugin to minimize images using imagemin.
 * [esbuild-plugin-import-glob](https://github.com/thomaschaaf/esbuild-plugin-import-glob): A plugin to import multiple files using the glob syntax. Similar to `require.context` from webpack.
 * [esbuild-plugin-inline-import](https://github.com/claviska/esbuild-plugin-inline-import): A plugin that inlines and optionally transforms imports with a configurable prefix.
+* [esbuild-plugin-liquid](https://github.com/jayelkaake/esbuild-plugin-liquid): A plugin that lets you import [Liquid](https://shopify.github.io/liquid/basics/introduction/) HTML template tiles into a string variable works.
 * [esbuild-plugin-lodash](https://github.com/josteph/esbuild-plugin-lodash): A plugin that helps tree-shake non-es lodash imports, similar to how [babel-plugin-lodash](https://github.com/lodash/babel-plugin-lodash) works.
 * [esbuild-plugin-manifest](https://github.com/jfortunato/esbuild-plugin-manifest): A plugin to generate a hashed asset manifest file.
 * [esbuild-plugin-mxn-copy](https://github.com/ZimNovich/esbuild-plugin-mxn-copy): A esbuild plugin for copying assets into the output directory of your bundle.


### PR DESCRIPTION
Add `esbuild-plugin-liquid` - A plugin that lets you import [Liquid](https://shopify.github.io/liquid/basics/introduction/) HTML template tiles into a string variable works.