### PR TITLE
chore: Add esbuild-plugin-deno-loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,6 @@ This is just a centralized list of 3rd-party plugins to make discovery easier. N
 * [esbuild-plugin-eval](https://deno.land/x/esbuild_plugin_eval): A plugin that evaluates a module before importing it.
 * [esbuild-plugin-http-fetch](https://deno.land/x/esbuild_plugin_http_fetch): A plugin that resolves http(s) modules, for use with browsers and Deno.
 * [esbuild-plugin-sass-deno](https://deno.land/x/esbuild_plugin_sass_deno@v0.1.0): A plugin which adds support for SASS/SCSS using `denosass`. 
-* [esbuild_deno_loader](https://deno.land/x/esbuild_deno_loader): A plugin that adds support for Deno module resolution (to use in Deno).
 
 ## How to use a plugin
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ This is just a centralized list of 3rd-party plugins to make discovery easier. N
 * [esbuild-plugin-write-file](https://github.com/ozanozbek/esbuild-plugin-write-file): A plugin for asynchronously creating/writing files in parallel before or after bundling.
 * [esbuild-plugins-node-modules-polyfill](https://github.com/imranbarbhuiya/esbuild-plugins-node-modules-polyfill): A plugin to polyfill nodejs builtin modules for the browser.
 * [esbuild-svelte-paths](https://github.com/alexxnb/esbuild-svelte-paths): A plugin that resolves shortcuted pathes for Svelte components.
+* [esbuild-plugin-deno-loader](https://github.com/gjsify/esbuild-plugin-deno-loader): A plugin that adds support for Deno module resolution (to use in Node.js).
 
 ### Plugins not hosted on npm (e.g. for Deno)
 
@@ -170,7 +171,8 @@ This is just a centralized list of 3rd-party plugins to make discovery easier. N
 * [esbuild-plugin-env](https://deno.land/x/esbuild_plugin_env): A plugin that exports the current environment as a module.
 * [esbuild-plugin-eval](https://deno.land/x/esbuild_plugin_eval): A plugin that evaluates a module before importing it.
 * [esbuild-plugin-http-fetch](https://deno.land/x/esbuild_plugin_http_fetch): A plugin that resolves http(s) modules, for use with browsers and Deno.
-* [esbuild-plugin-sass-deno](https://deno.land/x/esbuild_plugin_sass_deno@v0.1.0): A Plugin which adds support for SASS/SCSS using `denosass`. 
+* [esbuild-plugin-sass-deno](https://deno.land/x/esbuild_plugin_sass_deno@v0.1.0): A plugin which adds support for SASS/SCSS using `denosass`. 
+* [esbuild_deno_loader](https://deno.land/x/esbuild_deno_loader): A plugin that adds support for Deno module resolution (to use in Deno).
 
 ## How to use a plugin
 


### PR DESCRIPTION
This PR adds to esbuild plugins:

* [esbuild-plugin-deno-loader](https://github.com/gjsify/esbuild-plugin-deno-loader): A plugin that adds support for Deno module resolution (to use in Node.js).