### PR TITLE
Add esbuild-plugin-deepkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ This is just a centralized list of 3rd-party plugins to make discovery easier. N
 * [esbuild-plugin-write-file](https://github.com/ozanozbek/esbuild-plugin-write-file): A plugin for asynchronously creating/writing files in parallel before or after bundling.
 * [esbuild-plugins-node-modules-polyfill](https://github.com/imranbarbhuiya/esbuild-plugins-node-modules-polyfill): A plugin to polyfill nodejs builtin modules for the browser.
 * [esbuild-svelte-paths](https://github.com/alexxnb/esbuild-svelte-paths): A plugin that resolves shortcuted pathes for Svelte components.
+* [esbuild-plugin-deepkit](https://github.com/gjsify/gjsify/tree/main/packages/infra/esbuild-plugin-deepkit#readme): A plugin for the transformer of [@deepkit/type](https://deepkit.io/library/type) for TypeScript Runtime types.
 
 ### Plugins not hosted on npm (e.g. for Deno)
 


### PR DESCRIPTION
This add the following new plugin to the list:
* [esbuild-plugin-deepkit](https://github.com/gjsify/gjsify/tree/main/packages/infra/esbuild-plugin-deepkit#readme): A plugin for the transformer of [@deepkit/type](https://deepkit.io/library/type) for TypeScript Runtime types.