### PR TITLE
Add esbuild-plugin-transform-ext

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ This is just a centralized list of 3rd-party plugins to make discovery easier. N
 * [esbuild-plugin-write-file](https://github.com/ozanozbek/esbuild-plugin-write-file): A plugin for asynchronously creating/writing files in parallel before or after bundling.
 * [esbuild-plugins-node-modules-polyfill](https://github.com/imranbarbhuiya/esbuild-plugins-node-modules-polyfill): A plugin to polyfill nodejs builtin modules for the browser.
 * [esbuild-svelte-paths](https://github.com/alexxnb/esbuild-svelte-paths): A plugin that resolves shortcuted pathes for Svelte components.
+* [esbuild-plugin-transform-ext](https://github.com/gjsify/gjsify/tree/main/packages/infra/esbuild-plugin-transform-ext#readme): A plugin to transform import file extensions, e.g. `.ts` to `.js`.
 
 ### Plugins not hosted on npm (e.g. for Deno)
 


### PR DESCRIPTION
This adds the following plugin to the list:
* [esbuild-plugin-transform-ext](https://github.com/gjsify/gjsify/tree/main/packages/infra/esbuild-plugin-transform-ext#readme): A plugin to transform import file extensions, e.g. `.ts` to `.js`.