### PR TITLE
Add esbuild-plugin-summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ This is just a centralized list of 3rd-party plugins to make discovery easier. N
 * [esbuild-plugin-sixsixsix-killer](https://github.com/inqnuam/esbuild-plugin-sixsixsix-killer): Remove bloc of code when 'if' statement meets 666 condition
 * [esbuild-plugin-solid-js](https://gitlab.com/hesxenon/esbuild-plugin-solid-js/-/tree/main): A plugin to apply solids jsx transforms with esbuild (without breaking/dropping sourcemaps)
 * [esbuild-plugin-stimulus](https://github.com/zombiezen/esbuild-plugin-stimulus): A plugin to automatically [load Stimulus controllers](https://stimulus.hotwire.dev/handbook/installing) from a folder.
+* [esbuild-plugin-summary](https://github.com/devm33/esbuild-plugin-summary): A plugin to output the CLI build summary, time and filesize, when using the API.
 * [esbuild-plugin-swc](https://github.com/sanyuan0704/esbuild-plugin-swc): A plugin to support swc transform in Esbuild.
 * [esbuild-plugin-text-replace](https://github.com/aheissenberger/esbuild-plugin-text-replace): Replace content before bundling with support for Filefilter, Namespace, Regex and Functions.
 * [esbuild-plugin-time](https://github.com/DasRed/esbuild-plugin-time): A simple plugin for time measuring of the build process.


### PR DESCRIPTION
Adds plugin:

* [esbuild-plugin-summary](https://github.com/devm33/esbuild-plugin-summary): A plugin to output the CLI build summary, time and filesize, when using the API.