### PR TITLE
Add glob-import-esbuild-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ This is just a centralized list of 3rd-party plugins to make discovery easier. N
 * [esbuild-plugin-write-file](https://github.com/ozanozbek/esbuild-plugin-write-file): A plugin for asynchronously creating/writing files in parallel before or after bundling.
 * [esbuild-plugins-node-modules-polyfill](https://github.com/imranbarbhuiya/esbuild-plugins-node-modules-polyfill): A plugin to polyfill nodejs builtin modules for the browser.
 * [esbuild-svelte-paths](https://github.com/alexxnb/esbuild-svelte-paths): A plugin that resolves shortcuted pathes for Svelte components.
+* [glob-import-esbuild-plugin](https://github.com/Simonpedro/glob-import-esbuild-plugin): Use globs to import multiple modules based on Vite's `import.meta.glob`.
 * [react-native-esbuild](https://github.com/oblador/react-native-esbuild): Bundler and dev server for react-native using esbuild.
 
 ### Plugins for Deno


### PR DESCRIPTION
- This plugin allows importing multiple modules by using a glob pattern, e.g `components/**/*_component.js`.
- The import result is similar to [Vite's `import.meta.glob` one](https://vitejs.dev/guide/features#glob-import): It returns an object where the key is the module path, and the value are the exports (both named and default exports).
- There is a similar plugin already listed ([esbuild-plugin-import-glob](https://github.com/thomaschaaf/esbuild-plugin-import-glob)) but doesn't work without a default export, and the import result is quite different (returns an array of the module's exports, which makes it harder to know which module belongs to which path).

Thank you!
