### PR TITLE
feat: added esbuild-plugin-package-json

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ This is just a centralized list of 3rd-party plugins to make discovery easier. N
 * [esbuild-plugin-mxn-copy](https://github.com/ZimNovich/esbuild-plugin-mxn-copy): A esbuild plugin for copying assets into the output directory of your bundle.
 * [esbuild-plugin-node-externals](https://github.com/LinbuduLab/nx-plugins/tree/main/packages/esbuild-plugin-node-externals): esbuild plugin for node externals handing.
 * [esbuild-plugin-output-reset](https://github.com/yamitsushi/esbuild-plugin-output-reset): Minimal plugin to clean output before starting a new build.
+* [esbuild-plugin-package-json](https://github.com/simonkovtyk/esbuild-plugin-package-json): Prepares the package.json by removing all unnecessary fields and copying it to the out folder.
 * [esbuild-plugin-path-alias](https://github.com/indooorsman/esbuild-plugin-path-alias): A esbuild plugin to support path alias like `resolve.alias` in webpack config.
 * [esbuild-plugin-pino](https://github.com/davipon/esbuild-plugin-pino): An esbuild plugin to generate extra pino files for bundling
 * [esbuild-plugin-pipe](https://github.com/nativew/esbuild-plugin-pipe): A plugin to pipe the output of esbuild plugins.


### PR DESCRIPTION
Hi, I added my new plugin for preparing the package.json and copying it to the out-folder of esbuild.

I hope it helps other developers to have a better workflow while deploying packages to remote registries.