### PR TITLE
Add esbuild-plugin-postcss from JSR

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ This is just a centralized list of 3rd-party plugins to make discovery easier. N
 * [esbuild-plugin-eval](https://deno.land/x/esbuild_plugin_eval): A plugin that evaluates a module before importing it.
 * [esbuild-plugin-http-fetch](https://deno.land/x/esbuild_plugin_http_fetch): A plugin that resolves http(s) modules, for use with browsers and Deno.
 * [esbuild-plugin-sass-deno](https://deno.land/x/esbuild_plugin_sass_deno@v0.1.0): A Plugin which adds support for SASS/SCSS using `denosass`.
+* [esbuild-plugin-postcss](https://jsr.io/@udibo/esbuild-plugin-postcss): A plugin that makes it easy to use PostCSS with Deno. Supports CSS Modules, Sass, Less, and Stylus.
 
 ## How to use a plugin
 


### PR DESCRIPTION
This adds the esbuild-plugin-postcss package that I published to JSR. JSR is Deno's package manager.

https://jsr.io/@udibo/esbuild-plugin-postcss